### PR TITLE
[OVZC-46] 유저 관리

### DIFF
--- a/src/main/java/kr/ac/kgu/kpserver/config/WebMvcSecurityConfig.java
+++ b/src/main/java/kr/ac/kgu/kpserver/config/WebMvcSecurityConfig.java
@@ -1,17 +1,24 @@
 package kr.ac.kgu.kpserver.config;
 
+import kr.ac.kgu.kpserver.domain.user.UserService;
+import kr.ac.kgu.kpserver.handler.CustomUserHandlerMethodArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebMvcSecurityConfig implements WebMvcConfigurer {
 
     private final WebProperty webProperty;
+    private final UserService userService;
 
-    public WebMvcSecurityConfig(WebProperty webProperty) {
+    public WebMvcSecurityConfig(WebProperty webProperty, UserService userService) {
         this.webProperty = webProperty;
+        this.userService = userService;
     }
 
     @Override
@@ -29,5 +36,10 @@ public class WebMvcSecurityConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
         ;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new CustomUserHandlerMethodArgumentResolver(userService));
     }
 }

--- a/src/main/java/kr/ac/kgu/kpserver/domain/bmi/BMI.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/bmi/BMI.java
@@ -1,0 +1,16 @@
+package kr.ac.kgu.kpserver.domain.bmi;
+
+import kr.ac.kgu.kpserver.domain.user.User;
+
+public class BMI {
+    public static BMIResponse calculate(User user) {
+        Double heightByMeter = user.getHeight() / 100.0;
+        Double weight = user.getWeight();
+
+        double value = weight / (heightByMeter * heightByMeter);
+        double round = Math.round(value * 10) / 10.0;
+        BMIType type = BMIType.from(round);
+
+        return new BMIResponse(round, type.getDescription());
+    }
+}

--- a/src/main/java/kr/ac/kgu/kpserver/domain/bmi/BMIResponse.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/bmi/BMIResponse.java
@@ -1,0 +1,13 @@
+package kr.ac.kgu.kpserver.domain.bmi;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BMIResponse {
+
+    private final Double value;
+    private final String description;
+
+}

--- a/src/main/java/kr/ac/kgu/kpserver/domain/bmi/BMIType.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/bmi/BMIType.java
@@ -1,0 +1,35 @@
+package kr.ac.kgu.kpserver.domain.bmi;
+
+import kr.ac.kgu.kpserver.util.KpException;
+import kr.ac.kgu.kpserver.util.KpExceptionType;
+
+import java.util.Arrays;
+
+public enum BMIType {
+    UNDERWEIGHT("저체중", 0.0, 18.5),
+    HEALTHY("정상", 18.5, 23.0),
+    OVERWEIGHT("과체중", 23.0, 25.0),
+    MILDLY_OBESE("경도비만", 25.0, 30.0),
+    SEVERELY_OBESE("고도비만", 30.0, Double.MAX_VALUE);
+
+    private final String description;
+    private final Double minimumValue;
+    private final Double maximumValue;
+
+    public String getDescription() {
+        return description;
+    }
+
+    BMIType(String description, Double minimumValue, Double maximumValue) {
+        this.description = description;
+        this.minimumValue = minimumValue;
+        this.maximumValue = maximumValue;
+    }
+
+    public static BMIType from(Double value) {
+        return Arrays.stream(values())
+                .filter((type) -> type.minimumValue <= value && value < type.maximumValue)
+                .findFirst()
+                .orElseThrow(() -> new KpException(KpExceptionType.ILLEGAL_ARGUMENT));
+    }
+}

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/UserController.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/UserController.java
@@ -1,14 +1,14 @@
 package kr.ac.kgu.kpserver.domain.user;
 
 import kr.ac.kgu.kpserver.domain.user.dto.UserDto;
-import kr.ac.kgu.kpserver.domain.user.dto.UserSignUpRequest;
+import kr.ac.kgu.kpserver.domain.user.dto.UserRequest;
+import kr.ac.kgu.kpserver.security.UserAuthenticated;
 import kr.ac.kgu.kpserver.util.KpException;
 import kr.ac.kgu.kpserver.util.KpExceptionType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.security.Principal;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -20,31 +20,22 @@ public class UserController {
         this.userService = userService;
     }
 
+    @UserAuthenticated
     @GetMapping("/me")
-    public ResponseEntity<?> getMyInfo(Principal principal) {
-        long userId = Long.parseLong(principal.getName());
-        User user = userService.findUserByIdOrNull(userId);
-        if (user == null) {
-            throw new KpException(KpExceptionType.NOT_FOUND_USER);
-        }
+    public ResponseEntity<?> getMyInfo(User user) {
         return ResponseEntity.ok().body(UserDto.from(user));
     }
 
+    @UserAuthenticated
     @PostMapping("/sign-up")
     public ResponseEntity<?> signUp(
-            @Valid @RequestBody UserSignUpRequest userSignUpRequest,
-            Principal principal
+            @Valid @RequestBody UserRequest userRequest,
+            User user
     ) {
-        long userId = Long.parseLong(principal.getName());
-        User user = userService.findUserByIdOrNull(userId);
-        if (user == null) {
-            throw new KpException(KpExceptionType.NOT_FOUND_USER);
-        }
         if (user.getExerciseGroup() != null) {
             throw new KpException(KpExceptionType.ALREADY_SIGN_UP);
         }
-
-        userService.signUpUser(user, userSignUpRequest);
+        userService.updateUser(user, userRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/UserController.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/UserController.java
@@ -35,7 +35,17 @@ public class UserController {
         if (user.getExerciseGroup() != null) {
             throw new KpException(KpExceptionType.ALREADY_SIGN_UP);
         }
-        userService.updateUser(user, userRequest);
-        return ResponseEntity.ok().build();
+        User signUpUser = userService.updateUser(user, userRequest);
+        return ResponseEntity.ok(UserDto.from(signUpUser));
+    }
+
+    @UserAuthenticated
+    @PutMapping("/me")
+    public ResponseEntity<?> updateMyInfo(
+            @Valid @RequestBody UserRequest userRequest,
+            User user
+    ) {
+        User updatedUser = userService.updateUser(user, userRequest);
+        return ResponseEntity.ok(UserDto.from(updatedUser));
     }
 }

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/UserController.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/UserController.java
@@ -48,4 +48,11 @@ public class UserController {
         User updatedUser = userService.updateUser(user, userRequest);
         return ResponseEntity.ok(UserDto.from(updatedUser));
     }
+
+    @UserAuthenticated
+    @DeleteMapping("/me")
+    public ResponseEntity<?> withdrawal(User user) {
+        userService.deleteUser(user);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/UserService.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/UserService.java
@@ -73,6 +73,11 @@ public class UserService {
         return userRepository.save(updatedUser);
     }
 
+    @Transactional
+    public void deleteUser(User user) {
+        userRepository.delete(user);
+    }
+
     private User upsertUser(User userRequest) {
         User user = userRepository.findByEmail(userRequest.getEmail()).orElse(userRequest);
         user.setFirstName(userRequest.getFirstName());

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/UserService.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/UserService.java
@@ -5,7 +5,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import kr.ac.kgu.kpserver.config.OAuth2Property;
-import kr.ac.kgu.kpserver.domain.user.dto.UserSignUpRequest;
+import kr.ac.kgu.kpserver.domain.user.dto.UserRequest;
 import kr.ac.kgu.kpserver.security.JwtAuthenticator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
@@ -41,6 +41,7 @@ public class UserService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public User findUserByIdOrNull(Long id) {
         return userRepository.findById(id).orElse(null);
     }
@@ -56,17 +57,18 @@ public class UserService {
         return jwtAuthenticator.createToken(user, false);
     }
 
-    public void signUpUser(User user, UserSignUpRequest userSignUpRequest) {
+    @Transactional
+    public void updateUser(User user, UserRequest userRequest) {
         User updatedUser = user.update(
-                userSignUpRequest.getGender(),
-                userSignUpRequest.getDateOfBirth(),
-                userSignUpRequest.getHeight(),
-                userSignUpRequest.getWeight(),
-                userSignUpRequest.getMbti(),
-                userSignUpRequest.getExerciseGroup(),
-                userSignUpRequest.getStressPoint(),
-                userSignUpRequest.getIsSmoking(),
-                userSignUpRequest.getIsAlcohol()
+                userRequest.getGender(),
+                userRequest.getDateOfBirth(),
+                userRequest.getHeight(),
+                userRequest.getWeight(),
+                userRequest.getMbti(),
+                userRequest.getExerciseGroup(),
+                userRequest.getStressPoint(),
+                userRequest.getIsSmoking(),
+                userRequest.getIsAlcohol()
         );
         userRepository.save(updatedUser);
     }

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/UserService.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/UserService.java
@@ -58,7 +58,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUser(User user, UserRequest userRequest) {
+    public User updateUser(User user, UserRequest userRequest) {
         User updatedUser = user.update(
                 userRequest.getGender(),
                 userRequest.getDateOfBirth(),
@@ -70,7 +70,7 @@ public class UserService {
                 userRequest.getIsSmoking(),
                 userRequest.getIsAlcohol()
         );
-        userRepository.save(updatedUser);
+        return userRepository.save(updatedUser);
     }
 
     private User upsertUser(User userRequest) {

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/dto/UserDto.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/dto/UserDto.java
@@ -1,5 +1,7 @@
 package kr.ac.kgu.kpserver.domain.user.dto;
 
+import kr.ac.kgu.kpserver.domain.bmi.BMI;
+import kr.ac.kgu.kpserver.domain.bmi.BMIResponse;
 import kr.ac.kgu.kpserver.domain.mbti.MBTI;
 import kr.ac.kgu.kpserver.domain.user.Gender;
 import kr.ac.kgu.kpserver.domain.user.User;
@@ -24,6 +26,7 @@ public class UserDto {
     private final Integer stressPoint;
     private final Boolean isSmoking;
     private final Boolean isAlcohol;
+    private final BMIResponse bmi;
 
 
     public static UserDto from(User user) {
@@ -40,6 +43,7 @@ public class UserDto {
                 .stressPoint(user.getStressPoint())
                 .isSmoking(user.getIsSmoking())
                 .isAlcohol(user.getIsAlcohol())
+                .bmi(BMI.calculate(user))
                 .build();
     }
 }

--- a/src/main/java/kr/ac/kgu/kpserver/domain/user/dto/UserRequest.java
+++ b/src/main/java/kr/ac/kgu/kpserver/domain/user/dto/UserRequest.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 
 @Data
 @Builder
-public class UserSignUpRequest {
+public class UserRequest {
 
     @NotNull
     private final Gender gender;

--- a/src/main/java/kr/ac/kgu/kpserver/handler/CustomUserHandlerMethodArgumentResolver.java
+++ b/src/main/java/kr/ac/kgu/kpserver/handler/CustomUserHandlerMethodArgumentResolver.java
@@ -1,0 +1,44 @@
+package kr.ac.kgu.kpserver.handler;
+
+import kr.ac.kgu.kpserver.domain.user.User;
+import kr.ac.kgu.kpserver.domain.user.UserService;
+import kr.ac.kgu.kpserver.security.UserAuthenticated;
+import kr.ac.kgu.kpserver.util.KpException;
+import kr.ac.kgu.kpserver.util.KpExceptionType;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CustomUserHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+
+    public CustomUserHandlerMethodArgumentResolver(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasMethodAnnotation(UserAuthenticated.class) && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new KpException(KpExceptionType.AUTHENTICATION_FAILED);
+        }
+        Long userId = (Long) authentication.getPrincipal();
+        User user = userService.findUserByIdOrNull(userId);
+        if (user == null) {
+            throw new KpException(KpExceptionType.NOT_FOUND_USER);
+        }
+        return user;
+    }
+}

--- a/src/main/java/kr/ac/kgu/kpserver/security/UserAuthenticated.java
+++ b/src/main/java/kr/ac/kgu/kpserver/security/UserAuthenticated.java
@@ -1,0 +1,11 @@
+package kr.ac.kgu.kpserver.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface UserAuthenticated {
+}

--- a/src/main/java/kr/ac/kgu/kpserver/util/KpExceptionType.java
+++ b/src/main/java/kr/ac/kgu/kpserver/util/KpExceptionType.java
@@ -6,6 +6,7 @@ public enum KpExceptionType {
 
         NOT_FOUND_USER(HttpStatus.NOT_FOUND, 101, "해당 유저를 찾을 수 없습니다."),
         ALREADY_SIGN_UP(HttpStatus.BAD_REQUEST, 102, "이미 회원가입한 유저 입니다."),
+        AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, 103, "인증에 실패했습니다."),
 
         TEST(HttpStatus.BAD_REQUEST, 999, "ERROR MESSAGE");
 

--- a/src/main/java/kr/ac/kgu/kpserver/util/KpExceptionType.java
+++ b/src/main/java/kr/ac/kgu/kpserver/util/KpExceptionType.java
@@ -4,19 +4,21 @@ import org.springframework.http.HttpStatus;
 
 public enum KpExceptionType {
 
-        NOT_FOUND_USER(HttpStatus.NOT_FOUND, 101, "해당 유저를 찾을 수 없습니다."),
-        ALREADY_SIGN_UP(HttpStatus.BAD_REQUEST, 102, "이미 회원가입한 유저 입니다."),
-        AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, 103, "인증에 실패했습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, 101, "해당 유저를 찾을 수 없습니다."),
+    ALREADY_SIGN_UP(HttpStatus.BAD_REQUEST, 102, "이미 회원가입한 유저 입니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, 103, "인증에 실패했습니다."),
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, 104, "부적절한 값입니다."),
 
-        TEST(HttpStatus.BAD_REQUEST, 999, "ERROR MESSAGE");
 
-        public final HttpStatus httpStatus;
-        public final int errorCode;
-        public final String errorMessage;
+    TEST(HttpStatus.BAD_REQUEST, 999, "ERROR MESSAGE");
 
-        KpExceptionType(HttpStatus httpStatus, int errorCode, String errorMessage) {
-            this.httpStatus = httpStatus;
-            this.errorCode = errorCode;
-            this.errorMessage = errorMessage;
-        }
+    public final HttpStatus httpStatus;
+    public final int errorCode;
+    public final String errorMessage;
+
+    KpExceptionType(HttpStatus httpStatus, int errorCode, String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
     }
+}


### PR DESCRIPTION
- 유저 회원 정보 수정 API
- 유저 회원 탈퇴 API
- 유저 조회 API에 bmi 응답 추가

- - -
- 인증된 유저 정보를 컨트롤러 메서드의 파라미터에서 주입하도록 개선

AS-IS

```java
    @GetMapping("/me")
    public ResponseEntity<?> getMyInfo(Principal principal) {
        long userId = Long.parseLong(principal.getName());
        User user = userService.findUserByIdOrNull(userId);
        if (user == null) {
            throw new KpException(KpExceptionType.NOT_FOUND_USER);
        }
        return ResponseEntity.ok().body(UserDto.from(user));
    }
```

TO-BE

```java
    @UserAuthenticated
    @GetMapping("/me")
    public ResponseEntity<?> getMyInfo(User user) {
        return ResponseEntity.ok().body(UserDto.from(user));
    }
```